### PR TITLE
feat: add a new type QueryResult to use intead of List

### DIFF
--- a/DETAILED_GUIDE.md
+++ b/DETAILED_GUIDE.md
@@ -47,6 +47,9 @@ Future<List<Resource>> rs = store.list("posts"); // GET "/posts"
 Future<List<Resource>> rs = store.list("posts", params: {"createdAfter": '2014'}); // GET "/posts?createdAfter=2014"
 ```
 
+Actually, the `list` method returns an instance of `QueryResult`. It is a list with an extra property: `meta`, which can be used by the backend to pass extra information to the client (e.g., pagination).
+
+
 
 
 ### Nested Resources

--- a/lib/src/object_store.dart
+++ b/lib/src/object_store.dart
@@ -16,13 +16,13 @@ class ObjectStore {
   Future one(type, id)  =>
       _resourceQueryOne(type, (rt) => resourceStore.one(rt, id));
 
-  Future<List> list(type, {Map params}) =>
+  Future<QueryResult> list(type, {Map params}) =>
       _resourceQueryList(type, (rt) => resourceStore.list(rt, params: params));
 
   Future customQueryOne(type, CustomRequestParams params) =>
       _resourceQueryOne(type, (rt) => resourceStore.customQueryOne(rt, params));
 
-  Future<List> customQueryList(type, CustomRequestParams params) =>
+  Future<QueryResult> customQueryList(type, CustomRequestParams params) =>
       _resourceQueryList(type, (rt) => resourceStore.customQueryList(rt, params));
 
 
@@ -47,7 +47,7 @@ class ObjectStore {
 
   _resourceQueryList(type, function) {
     final rt = config.resourceType(type);
-    deserialize(list) => _wrappedListIntoFuture(list.map(config.deserializer(rt, ['query'])).toList());
+    deserialize(list) => _wrappedListIntoFuture(list.map(config.deserializer(rt, ['query'])));
     return function(rt).then(deserialize);
   }
 

--- a/lib/src/resource_store.dart
+++ b/lib/src/resource_store.dart
@@ -22,7 +22,7 @@ class ResourceStore {
     return _invoke("GET", url).then(_parseResource(resourceType));
   }
 
-  Future<List<Resource>> list(resourceType, {Map params}) {
+  Future<QueryResult<Resource>> list(resourceType, {Map params}) {
     final url = _url(resourceType);
     return _invoke("GET", url, params: params).then(_parseManyResources((resourceType)));
   }
@@ -30,7 +30,7 @@ class ResourceStore {
   Future<Resource> customQueryOne(resourceType, CustomRequestParams params) =>
       params.invoke(http).then(_parseResource(resourceType));
 
-  Future<List<Resource>> customQueryList(resourceType, CustomRequestParams params)  =>
+  Future<QueryResult<Resource>> customQueryList(resourceType, CustomRequestParams params)  =>
       params.invoke(http).then(_parseManyResources(resourceType));
 
 

--- a/test/src/integration_test.dart
+++ b/test/src/integration_test.dart
@@ -100,6 +100,6 @@ class JsonApiOrgFormat extends JsonDocumentFormat {
   Resource jsonToResource(type, json) =>
       resource(type, json[type][0]["id"], json[type][0]);
 
-  List<Resource> jsonToManyResources(type, json) =>
+  QueryResult<Resource> jsonToManyResources(type, json) =>
       json[type].map((r) => resource(type, r["id"], r)).toList();
 }


### PR DESCRIPTION
QueryResult is a list with an extra property called `meta`. This property can be used by the backend to pass extra information to the client.

Closes #14
